### PR TITLE
NP-2402 cluster decommission

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -229,12 +229,12 @@
   version = "v0.0.38"
 
 [[projects]]
-  digest = "1:962c57de2d67417d5d12e425a7e78f8caf0cac1d946dc924abf14ada676f982f"
+  digest = "1:c6c5d47ad6a7bab895de3a6d51194e6d08ac11d69b57220a036712632d96bb93"
   name = "github.com/nalej/grpc-conductor-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "97e91f492ecb1ddb85ba746189121655d4c3fe75"
-  version = "v0.0.93"
+  revision = "9cbe44351c8dbd004186abc61dff0430d497022a"
+  version = "v0.0.96"
 
 [[projects]]
   digest = "1:d82da4b7759b7744585f7c854fa980cd6e705f473a0705e97abdf11c537d47a4"
@@ -360,6 +360,7 @@
   version = "v1.5.0"
 
 [[projects]]
+  branch = "master"
   digest = "1:37824da4f75c5237741e73da12a987e160e8094c05aca654a570cc3f260c5433"
   name = "github.com/nalej/nalej-bus"
   packages = [
@@ -370,8 +371,7 @@
     "pkg/queue/infrastructure/ops",
   ]
   pruneopts = "UT"
-  revision = "1dd74ce7d95af3f0b5f15f27043c0255ee0a05d1"
-  version = "v0.4.0"
+  revision = "6ea3eae7779c2e274170fb4441878c5fb3c0b9cc"
 
 [[projects]]
   digest = "1:42e29deef12327a69123b9cb2cb45fee4af5c12c2a23c6e477338279a052703f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,8 @@
 
 [[constraint]]
     name="github.com/nalej/nalej-bus"
-    version="=v0.4.0"
+#    version="=v0.4.0"
+    branch="master"
 
 [[constraint]]
     name="github.com/nalej/grpc-common-go"
@@ -32,7 +33,7 @@
 
  [[constraint]]
     name="github.com/nalej/grpc-conductor-go"
-    version="=v0.0.93"
+    version="=v0.0.96"
 
  [[constraint]]
     name="github.com/nalej/grpc-application-go"

--- a/internal/pkg/monitor/decomissioner.go
+++ b/internal/pkg/monitor/decomissioner.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Nalej
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monitor
+
+import (
+	"context"
+	"github.com/nalej/derrors"
+	"github.com/nalej/grpc-common-go"
+	"github.com/nalej/grpc-provisioner-go"
+	"github.com/nalej/grpc-utils/pkg/conversions"
+	"github.com/rs/zerolog/log"
+	"time"
+)
+
+// DecomissionerMonitor structure with the required clients to read and update states of a decomission.
+type DecomissionerMonitor struct {
+	decomissionerClient grpc_provisioner_go.DecomissionClient
+	clusterId           string
+	requestId           string
+	callback            func(string, *grpc_common_go.OpResponse, derrors.Error)
+}
+
+// NewDecomissionerMonitor creates a new monitor with a set of clients.
+func NewDecomissionerMonitor(
+	decomissionerClient grpc_provisioner_go.DecomissionClient,
+	clusterId string,
+	requestId string) *DecomissionerMonitor {
+	return &DecomissionerMonitor{
+		decomissionerClient: decomissionerClient,
+		clusterId:           clusterId,
+		requestId:           requestId,
+		callback:            nil,
+	}
+}
+
+// RegisterCallback registers a callback function that will be triggered
+// when the decomission of a cluster finishes.
+func (m *DecomissionerMonitor) RegisterCallback(callback func(clusterID string, lastResponse *grpc_common_go.OpResponse, err derrors.Error)) {
+	m.callback = callback
+}
+
+// LaunchMonitor periodically monitors the state of a decomission waiting for it to complete.
+func (m *DecomissionerMonitor) LaunchMonitor() {
+	log.Debug().Str("clusterID", m.clusterId).
+		Str("requestID", m.requestId).Msg("Launching decomission monitor")
+
+	requestID := &grpc_common_go.RequestId{
+		RequestId: m.requestId,
+	}
+	exit := false
+	remainingFailures := MaxConnFailures
+	var status *grpc_common_go.OpResponse
+	var err error
+	for !exit {
+		status, err = m.decomissionerClient.CheckProgress(context.Background(), requestID)
+		if err != nil {
+			log.Debug().Str("err", conversions.ToDerror(err).DebugReport()).Msg("error requesting decomissioning status")
+			remainingFailures--
+			if remainingFailures == 0 {
+				log.Warn().Str("requestID", requestID.RequestId).Msg("Cannot contact provisioner")
+				exit = true
+			} else {
+				time.Sleep(ConnectRetryDelay)
+			}
+		} else {
+			log.Debug().Str("requestID", requestID.RequestId).Int64("elapsed", status.ElapsedTime).Str("state", status.Status.String()).Msg("processing decomission progress")
+			if status.Error != "" || status.Status == grpc_common_go.OpStatus_FAILED || status.Status == grpc_common_go.OpStatus_CANCELED || status.Status == grpc_common_go.OpStatus_SUCCESS {
+				exit = true
+			} else {
+				time.Sleep(QueryDelay)
+			}
+		}
+	}
+	m.notify(status, err)
+	log.Debug().Str("clusterID", m.clusterId).
+		Str("requestID", m.requestId).Msg("Decomission monitor exits")
+}
+
+// notify informs the associated callback that the installation has finished.
+func (m *DecomissionerMonitor) notify(lastResponse *grpc_common_go.OpResponse, err error) {
+	requestID := &grpc_common_go.RequestId{
+		RequestId: lastResponse.GetRequestId(),
+	}
+	_, rErr := m.decomissionerClient.RemoveDecomission(context.Background(), requestID)
+	if rErr != nil {
+		log.Error().Str("requestID", requestID.RequestId).
+			Str("err", conversions.ToDerror(rErr).DebugReport()).Msg("Cannot remove decomission from provisioner")
+	}
+	var cErr derrors.Error
+	if err != nil {
+		cErr = conversions.ToDerror(err)
+	}
+	if m.callback != nil {
+		m.callback(m.clusterId, lastResponse, cErr)
+	} else {
+		log.Warn().Str("requestID", requestID.RequestId).
+			Msg("no callback registered")
+	}
+}

--- a/internal/pkg/server/infrastructure/handler.go
+++ b/internal/pkg/server/infrastructure/handler.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Nalej
+ * Copyright 2020 Nalej
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ func (h *Handler) Uninstall(_ context.Context, request *grpc_installer_go.Uninst
 		return nil, conversions.ToGRPCError(err)
 	}
 	request.RequestId = uuid.NewV4().String()
-	result, err := h.Manager.Uninstall(request)
+	result, err := h.Manager.Uninstall(request, nil)
 	if err != nil {
 		return nil, conversions.ToGRPCError(err)
 	}
@@ -92,7 +92,7 @@ func (h *Handler) DecomissionCluster(_ context.Context, request *grpc_provisione
 		return nil, conversions.ToGRPCError(err)
 	}
 	request.RequestId = uuid.NewV4().String()
-	result, err := h.Manager.DecomissionCluster(request)
+	result, err := h.Manager.UninstallAndDecomissionCluster(request)
 	if err != nil {
 		return nil, conversions.ToGRPCError(err)
 	}


### PR DESCRIPTION
#### What does this PR do?
Allow the decommission of application clusters through API.

**NOTE** This PR depends on [This other on provisioner](https://github.com/nalej/provisioner/pull/15).

#### How should this be manually tested?
1. Cordon a valid and drained application cluster.
2. Run:
```shell script
./public-api-cli cluster decomission {{cluster-id}} --targetPlatform AZURE --azureCredentialsPath /Users/mgarcia/.azure/mgarcia_provisioner.json --azureResourceGroup dev --clusterType KUBERNETES
```

#### What are the relevant tickets?

- [NP-2402](https://nalej.atlassian.net/browse/NP-2402)

#### Screenshots (if appropriate)

#### Questions
